### PR TITLE
chore(ci): configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,20 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    commit-message:
-      prefix: "feat: "
-    groups:
-      baseimages:
-        patterns:
-          - "*"
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: pip
     directory: "/"
     schedule:
       interval: "daily"
-    commit-message:
-      prefix: "chore(ci): "
-    open-pull-requests-limit: 10
-  - package-ecosystem: pip
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
# Initialize [GitHub Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates).

Configures Dependabot to create weekly update PRs.
