### PR TITLE
chore(ci): configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,22 @@
 version: 2
 updates:
-  - package-ecosystem: "docker"
-    directory: "/"
+  - package-ecosystem: docker
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
     commit-message:
-      prefix: "feat: "
+      prefix: "chore: "
     groups:
       baseimages:
         patterns:
           - "*"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
     commit-message:
       prefix: "chore(ci): "
-    open-pull-requests-limit: 10
   - package-ecosystem: pip
-    directory: "/"
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily


### PR DESCRIPTION
# Initialize [GitHub Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates).

Configures Dependabot to create regular update PRs.
